### PR TITLE
Fix RN alert about a new native modules initializing method

### DIFF
--- a/ios/VkontakteManager.m
+++ b/ios/VkontakteManager.m
@@ -138,4 +138,8 @@ RCT_REMAP_METHOD(logout, resolver:(RCTPromiseResolveBlock)resolve rejecter:(RCTP
   }
 }
 
++ (BOOL)requiresMainQueueSetup {
+  return YES;
+}
+
 @end


### PR DESCRIPTION
Alert message from `RN` > `0.49`

> Module RealmReact requires main queue setup since it overrides constantsToExport but doesn't implement requiresMainQueueSetup. In a future release React Native will default to initializing all native modules on a background thread unless explicitly opted-out of.