### PR TITLE
[iOS] runtime error fix for latest RN versions

### DIFF
--- a/ios/VkontakteManager.m
+++ b/ios/VkontakteManager.m
@@ -56,7 +56,7 @@ RCT_EXPORT_MODULE();
 RCT_EXPORT_METHOD(initialize: (nonnull NSNumber *) appId) {
   DMLog(@"Initialize app id %@", appId);
 
-  sdk = [VKSdk initializeWithAppId:[appId stringValue]];
+  sdk = [VKSdk initializeWithAppId:[NSString stringWithFormat:@"%@", appId]];
   [sdk registerDelegate:self];
   [sdk setUiDelegate:self];
   [VKSdk wakeUpSession:@[] completeBlock:^(VKAuthorizationState state, NSError *error) {}];


### PR DESCRIPTION
There is a runtime error happening only in latest RN versions (might be new iOS version and Obj-C). The error is "Terminating app due to uncaught exception 'NSInvalidArgumentException', reason: '-[NSTaggedPointerString stringValue]: unrecognized selector sent to instance 0xbb689ad41de6145a'". So following changes work for me. It is not a lot but I thought it would cool to open a PR.